### PR TITLE
feat(mkdocs-action): Se agrega gh action de mkdocs y proyecto de ejemplo.

### DIFF
--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -1,0 +1,25 @@
+name: Publish docs via GitHub Pages
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v2
+
+      - name: Deploy docs
+        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        # Or use mhausenblas/mkdocs-deploy-gh-pages@nomaterial to build without the mkdocs-material theme
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Se comentan dominios por lo pronto.
+          #CUSTOM_DOMAIN: optionaldomain.com
+          CONFIG_FILE: folder/mkdocs.yml
+          EXTRA_PACKAGES: build-base
+          # GITHUB_DOMAIN: github.myenterprise.com
+          #REQUIREMENTS: folder/requirements.txt

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Bienvenido a la wiki DevOps de SPS
+
+Para mayor información con gusto puedes visitarnos [spsolutions.com.mx](https://www.spsolutions.com.mx).
+
+## Commands
+
+* `mkdocs new [dir-name]` - Create a new project.
+* `mkdocs serve` - Start the live-reloading docs server.
+* `mkdocs build` - Build the documentation site.
+* `mkdocs -h` - Print help message and exit.
+
+## Project layout
+
+    mkdocs.yml    # The configuration file.
+    docs/
+        index.md  # The documentation homepage.
+        ...       # Other markdown pages, images and other files.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,1 @@
+site_name: SPS Wiki


### PR DESCRIPTION
Se agrega acción de GIthub actions para mkdocs (https://github.com/marketplace/actions/deploy-mkdocs)
Se modifica el ejemplo de mkdocs, dentro de la carpeta de docs viene el archivo de configuración de mkdocs.
Se comentó la configuración de dominios con la idea de que se use uno generado por GitHub pages.

Parece ser que va a ser necesario configurar un token en los secretos.
